### PR TITLE
Add random amount of stars and 1up Mushrroms for each run/player 

### DIFF
--- a/worlds/smgalaxy/items.py
+++ b/worlds/smgalaxy/items.py
@@ -24,7 +24,8 @@ item_table: dict[str, SMGItemData] = {
   "Power Star": SMGItemData(["Power Star"], 170000004, IC.progression_deprioritized_skip_balancing),# rom address  0x007ACCA0F2FF8760 don't remeber how i found this or if it's acurate so could use double check.
   "Grand Star": SMGItemData(["Grand Star", "Power Star"], 170000005, IC.progression),
   "Green Star": SMGItemData(["Green Star", "Power Star"], 170000006, IC.progression),
-  "Nothing": SMGItemData(["Nothing Item"], 170000007, IC.filler),
+  "1up Mushroom": SMGItemData(["Nothing Item"], 170000007, IC.filler),
+  
   "Progressive Comets": SMGItemData(["Comet"], 170000008, IC.progression),
   "Peach": SMGItemData(["Victory"], None, IC.progression)
 

--- a/worlds/smgalaxy/items.py
+++ b/worlds/smgalaxy/items.py
@@ -24,7 +24,7 @@ item_table: dict[str, SMGItemData] = {
   "Power Star": SMGItemData(["Power Star"], 170000004, IC.progression_deprioritized_skip_balancing),# rom address  0x007ACCA0F2FF8760 don't remeber how i found this or if it's acurate so could use double check.
   "Grand Star": SMGItemData(["Grand Star", "Power Star"], 170000005, IC.progression),
   "Green Star": SMGItemData(["Green Star", "Power Star"], 170000006, IC.progression),
-  "1up Mushroom": SMGItemData(["Nothing Item"], 170000007, IC.filler),
+  "1up Mushroom": SMGItemData(["Filler Items"], 170000007, IC.filler),
   
   "Progressive Comets": SMGItemData(["Comet"], 170000008, IC.progression),
   "Peach": SMGItemData(["Victory"], None, IC.progression)

--- a/worlds/smgalaxy/world.py
+++ b/worlds/smgalaxy/world.py
@@ -117,9 +117,14 @@ class SMGWorld(World):
         self.multiworld.get_location("B: The Fate of the Universe", self.player).place_locked_item(self.create_item("Peach"))
         
         # make sure we don't create more stars than locations, somehow
-        star_count = min([109, (len(list(self.multiworld.get_unfilled_locations(self.player))) - len(local_pool))])
-        local_pool += [self.create_item("Power Star") for i in range(star_count)]
-
+        
+        local_pool += [self.create_item("Power Star") for i in range(self.options.stars_to_finish.value)]
+        leftoverlocations = min([109, (len(list(self.multiworld.get_unfilled_locations(self.player))) - len(local_pool))])
+        items = ["Power Star", "1up Mushroom"]
+        for _ in range(leftoverlocations):
+            item_name = self.random.choice(items)
+            item = self.create_item(item_name)
+            local_pool.append(item)
         # Calculate the number of additional filler items to create to fill all locations
         n_locations = len(self.multiworld.get_unfilled_locations(self.player))
         n_items = len(local_pool)
@@ -146,7 +151,6 @@ class SMGWorld(World):
     # Output options, locations and doors for patcher
     def generate_output(self, output_directory: str):
         # Output seed name and slot number to seed RNG in randomizer client
-        self.galaxy_counts.update({"D1G1": 0})
         output_data: dict = {
             AP_WORLD_VERSION_NAME: CLIENT_VERSION,
             "Seed": self.multiworld.seed,
@@ -170,13 +174,6 @@ class SMGWorld(World):
                 output_data["Options"][field.name] = list(output_data["Options"][field.name])
         output_data["Options"]["character_select"] = getattr(self.options, "character_select").value
         output_data["Options"]["mario_colors"] = getattr(self.options, "mario_colors").value
-
-
-        k = ["Dome 1", "Dome 2", "Dome 3", "Dome 4", "Dome 5", "Dome 6"]
-        if self.options.dome_shuffle.value:
-            self.random.shuffle(k)
-        v = [regname.TERRACE, regname.FOUNTAIN, regname.KITCHEN, regname.BEDROOM, regname.ENGINE, regname.GARDEN]
-        output_data["Options"]["dome_shuffle"] = dict(zip(k, v))
 
         # Output which item has been placed at each location
         for location in list(smgloc for smgloc in self.get_locations() if isinstance(smgloc, SMGLocation)):

--- a/worlds/smgalaxy/world.py
+++ b/worlds/smgalaxy/world.py
@@ -107,7 +107,7 @@ class SMGWorld(World):
         return item
 
     def get_filler_item_name(self) -> str:
-        return "Nothing"
+        return "1up Mushroom"
     
     def create_items(self):
         # creates the green stars in each player's itempool
@@ -117,18 +117,16 @@ class SMGWorld(World):
         self.multiworld.get_location("B: The Fate of the Universe", self.player).place_locked_item(self.create_item("Peach"))
         
         # make sure we don't create more stars than locations, somehow
-        
         local_pool += [self.create_item("Power Star") for i in range(self.options.stars_to_finish.value)]
-        leftoverlocations = min([109, (len(list(self.multiworld.get_unfilled_locations(self.player))) - len(local_pool))])
-        items = ["Power Star", "1up Mushroom"]
-        for _ in range(leftoverlocations):
-            item_name = self.random.choice(items)
-            item = self.create_item(item_name)
-            local_pool.append(item)
+        
         # Calculate the number of additional filler items to create to fill all locations
         n_locations = len(self.multiworld.get_unfilled_locations(self.player))
-        n_items = len(local_pool)
-        n_filler_items = n_locations - n_items
+        leftover_locations = min([109, (len(list(self.multiworld.get_unfilled_locations(self.player))) - len(local_pool))])
+        
+        # Add a random number of extra stars. Later, this can be made into an option.
+        extra_stars: int = self.random.randint(0, leftover_locations)
+        local_pool += [self.create_item("Power Star") for i in range(extra_stars)]
+        n_filler_items = n_locations - len(local_pool)
 
         # Create filler
         for _ in range(n_filler_items):

--- a/worlds/smgalaxy/world.py
+++ b/worlds/smgalaxy/world.py
@@ -150,6 +150,7 @@ class SMGWorld(World):
 
     # Output options, locations and doors for patcher
     def generate_output(self, output_directory: str):
+        self.galaxy_counts.update({"D1G1": 0})
         # Output seed name and slot number to seed RNG in randomizer client
         output_data: dict = {
             AP_WORLD_VERSION_NAME: CLIENT_VERSION,
@@ -174,6 +175,12 @@ class SMGWorld(World):
                 output_data["Options"][field.name] = list(output_data["Options"][field.name])
         output_data["Options"]["character_select"] = getattr(self.options, "character_select").value
         output_data["Options"]["mario_colors"] = getattr(self.options, "mario_colors").value
+
+        k = ["Dome 1", "Dome 2", "Dome 3", "Dome 4", "Dome 5", "Dome 6"]
+        if self.options.dome_shuffle.value:
+            self.random.shuffle(k)
+        v = [regname.TERRACE, regname.FOUNTAIN, regname.KITCHEN, regname.BEDROOM, regname.ENGINE, regname.GARDEN]
+        output_data["Options"]["dome_shuffle"] = dict(zip(k, v))
 
         # Output which item has been placed at each location
         for location in list(smgloc for smgloc in self.get_locations() if isinstance(smgloc, SMGLocation)):


### PR DESCRIPTION
## What is this fixing or adding?
Removes stars not needed for the goal and randomly per seed, adds them back in, or replaces them with 1up Mushrooms. Always makes sure that the correct number of stars needed to goal is in the pool. NOTE: Without this exclude locations will not work currently. This is currently not an option and always happens we could add an option if we want.

## How was this tested?
Both with single generation and with fuzzer 100 gens

## If this makes graphical changes, please attach screenshots.
